### PR TITLE
Add FuseSoC support and Github CI actions

### DIFF
--- a/.github/workflows/fusesoc.yml
+++ b/.github/workflows/fusesoc.yml
@@ -1,0 +1,33 @@
+name: run-fusesoc-targets
+on: [push]
+
+jobs:
+  build-openlane-sky130:
+    runs-on: ubuntu-latest
+    env:
+      REPO : blabla
+      VLNV : secworks:crypto:blabla
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: blabla
+      - run: echo "EDALIZE_LAUNCHER=el_docker" >> $GITHUB_ENV
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=sky130 $VLNV
+
+  lint-verilator:
+    runs-on: ubuntu-latest
+    env:
+      REPO : blabla
+      VLNV : secworks:crypto:blabla
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          path: blabla
+      - run: sudo apt install verilator
+      - run: pip3 install fusesoc
+      - run: fusesoc library add $REPO $GITHUB_WORKSPACE/$REPO
+      - run: fusesoc run --target=lint $VLNV

--- a/blabla.core
+++ b/blabla.core
@@ -1,0 +1,30 @@
+CAPI=2:
+
+name : secworks:crypto:blabla
+
+filesets:
+  rtl:
+    files:
+      - src/rtl/blabla_qr.v
+      - src/rtl/blabla_core.v
+    file_type : verilogSource
+
+  sky130:
+    files:
+      - data/sky130.tcl
+
+targets:
+  default:
+    filesets: [rtl]
+
+  lint:
+    default_tool : verilator
+    filesets : [rtl]
+    tools:
+      verilator: {mode: lint-only}
+    toplevel: blabla_core
+
+  sky130:
+    default_tool : openlane
+    filesets: [rtl, sky130]
+    toplevel : blabla_core

--- a/data/sky130.tcl
+++ b/data/sky130.tcl
@@ -1,0 +1,3 @@
+set ::env(CLOCK_PERIOD) "65.0"
+set ::env(CLOCK_PORT) "clk"
+set ::env(CLOCK_NET) $::env(CLOCK_PORT)


### PR DESCRIPTION
This adds a core description file for the blabla core that exposes targets for linting and for building a GDSII using OpenLANE. All targets are also implemented as Github actions so that they get run on every push to the repo.

Quick FuseSoC instructions:

 #install FuseSoC
pip3 install fusesoc
 #Create and enter a new workspace
mkdir workspace && cd workspace
 #Register blabla as a library in the workspace
fusesoc library add blabla /path/to/blabla
 #...if repo is available locally or...
fusesoc library add blabla https://github.com/secworks/blabla
 #...to get the upstream repo

 #To run lint
fusesoc run --target=lint secworks:crypto:blabla
 #To build with OpenLANE running in a docker container
EDALIZE_LAUNCHER=el_docker fusesoc run --target=sky130 secworks:crypto:blabla
 #List all targets
fusesoc core show secworks:crypto:blabla